### PR TITLE
fix: tambah validasi maxLength pada input registrasi user

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -19,9 +19,9 @@ export const usersRoute = new Elysia({ prefix: '/api' })
     }
   }, {
     body: t.Object({
-      name: t.String(),
-      email: t.String({ format: 'email' }),
-      password: t.String()
+      name: t.String({ maxLength: 255 }),
+      email: t.String({ format: 'email', maxLength: 255 }),
+      password: t.String({ maxLength: 255 })
     })
   })
   .post('/users/login', async ({ body, set }) => {


### PR DESCRIPTION
## Perubahan

Menambahkan `maxLength: 255` pada validasi body request di endpoint `POST /api/users` untuk field:
- `name`
- `email`
- `password`

## Alasan

Sebelumnya, jika user mengirimkan input yang melebihi batas `varchar(255)` di database, server akan mengembalikan **500 Internal Server Error**. Sekarang Elysia akan otomatis memvalidasi dan mengembalikan **422 Validation Error** sebelum query menyentuh database.

## Testing

Mengirim POST request dengan `name` sepanjang 300 karakter → server merespons dengan status **422** dan pesan error validasi yang jelas.

Closes #12